### PR TITLE
chore: remove deprecated redux-devtools-extension

### DIFF
--- a/plugins/devtools/package.json
+++ b/plugins/devtools/package.json
@@ -28,8 +28,8 @@
         "update:deps": "ncu -u"
     },
     "dependencies": {
-        "redux": "4.2.0",
-        "redux-devtools-extension": "2.13.9"
+        "@redux-devtools/extension": "3.3.0",
+        "redux": "4.2.0"
     },
     "peerDependencies": {
         "@redocly/hookstate-core": "^4.0.0"

--- a/plugins/devtools/src/devtools.ts
+++ b/plugins/devtools/src/devtools.ts
@@ -8,7 +8,7 @@ import {
 } from '@redocly/hookstate-core'
 
 import { createStore } from 'redux';
-import { devToolsEnhancer } from 'redux-devtools-extension';
+import { devToolsEnhancer } from '@redux-devtools/extension';
 
 function createReduxDevToolsLogger(
     stateAtRoot: State<StateValueAtRoot>, assignedId: string, onBreakpoint: () => void) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -591,12 +591,12 @@ importers:
 
   plugins/devtools:
     dependencies:
+      '@redux-devtools/extension':
+        specifier: 3.3.0
+        version: 3.3.0(redux@4.2.0)
       redux:
         specifier: 4.2.0
         version: 4.2.0
-      redux-devtools-extension:
-        specifier: 2.13.9
-        version: 2.13.9(redux@4.2.0)
     devDependencies:
       '@babel/core':
         specifier: 7.18.6
@@ -2960,6 +2960,11 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
+  '@redux-devtools/extension@3.3.0':
+    resolution: {integrity: sha512-X34S/rC8S/M1BIrkYD1mJ5f8vlH0BDqxXrs96cvxSBo4FhMdbhU+GUGsmNYov1xjSyLMHgo8NYrUG8bNX7525g==}
+    peerDependencies:
+      redux: ^3.1.0 || ^4.0.0 || ^5.0.0
+
   '@rollup/plugin-babel@5.3.1':
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
     engines: {node: '>= 10.0.0'}
@@ -3557,6 +3562,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -6002,6 +6008,9 @@ packages:
 
   immer@9.0.21:
     resolution: {integrity: sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==}
+
+  immutable@4.3.8:
+    resolution: {integrity: sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -8559,12 +8568,6 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
-
-  redux-devtools-extension@2.13.9:
-    resolution: {integrity: sha512-cNJ8Q/EtjhQaZ71c8I9+BPySIBVEKssbPpskBfsXqb8HJ002A3KRVHfeRzwRo6mGPqsm7XuHTqNSNeS1Khig0A==}
-    deprecated: Package moved to @redux-devtools/extension.
-    peerDependencies:
-      redux: ^3.1.0 || ^4.0.0
 
   redux@4.2.0:
     resolution: {integrity: sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==}
@@ -12629,7 +12632,7 @@ snapshots:
 
   '@docusaurus/react-loadable@5.5.2(react@19.1.0)':
     dependencies:
-      '@types/react': 19.1.5
+      '@types/react': 18.3.22
       prop-types: 15.8.1
       react: 19.1.0
 
@@ -13520,6 +13523,12 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
+  '@redux-devtools/extension@3.3.0(redux@4.2.0)':
+    dependencies:
+      '@babel/runtime': 7.27.1
+      immutable: 4.3.8
+      redux: 4.2.0
+
   '@rollup/plugin-babel@5.3.1(@babel/core@7.18.6)(@types/babel__core@7.20.5)(rollup@2.76.0)':
     dependencies:
       '@babel/core': 7.18.6
@@ -14064,7 +14073,7 @@ snapshots:
   '@types/react-router@5.1.20':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 19.1.5
+      '@types/react': 18.3.22
 
   '@types/react-transition-group@4.4.12(@types/react@19.1.5)':
     dependencies:
@@ -17340,6 +17349,8 @@ snapshots:
       queue: 6.0.2
 
   immer@9.0.21: {}
+
+  immutable@4.3.8: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -20640,10 +20651,6 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
-
-  redux-devtools-extension@2.13.9(redux@4.2.0):
-    dependencies:
-      redux: 4.2.0
 
   redux@4.2.0:
     dependencies:


### PR DESCRIPTION
# Details

Remove the deprecated `redux-devtools-extension` package and replace it with `@redux-devtools/extension` (a drop-in replacement).  Using the deprecated package causes warnings when installing via NPM: `npm warn deprecated redux-devtools-extension@2.13.9: Package moved to @redux-devtools/extension.`